### PR TITLE
added tests for GT-11229

### DIFF
--- a/test/load.js
+++ b/test/load.js
@@ -1,4 +1,6 @@
 var i18n = require('enyo/i18n'),
+	//require ilib for changing locale
+	ilib = require('enyo-ilib'),
 	ready = require('enyo/ready');
 
 var locale = window.location.hash.replace(/^#/, '');

--- a/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL-specs.js
+++ b/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL-specs.js
@@ -1,0 +1,47 @@
+var helpers = rootRequire('./helpers'),
+	app = {};	// Test-specific settings at bottom of the file
+
+var base = 'http://localhost:3000/',
+	path = 'test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL',
+	title = 'ExpandableInput - Keyboard Symbols display in LTR in RTL setting',
+	directory = 'ui-tests/dist',
+	tags = ['moonstone','rtl','ltr','symbols','qa','ExpandableInput'];	// Tags show up in SauceLabs test output
+
+describe(title, function() {
+	var browser;
+
+	before(function(done) {
+		browser = helpers.initBrowser(title, tags, base, path, done);
+	});
+
+	after(function(done) {
+		browser
+			.quit()
+			.nodeify(done);
+	});
+
+	it('should display keyboard symbols LTR in RTL setting' , function (done) {
+		browser
+			.setWindowSize(1920,1280)
+			.get(directory + '/#ur-PK')
+			.waitForElementById(app.expandableHeader)
+			.click()
+			.execute('ilib = require("enyo-ilib"); return ilib.getLocale()').should.eventually.equal('ur-PK')
+			.enyoPropertySet(app.input, 'value', app.textToInput)
+			.elementById(app.expandableHeader)
+			.click()
+			.elementById(app.headerText)
+			.text().should.eventually.equal(app.textToInput)
+			.elementById(app.headerText)
+			.getAttribute('style').should.eventually.contain('direction: ltr')
+			.nodeify(done);
+	});
+
+});
+
+app = {
+	expandableHeader: 'gT-11229-KeyboardSymbolsDisplayLTRinRTL_expandableInput_header_header',
+	input: 'gT-11229-KeyboardSymbolsDisplayLTRinRTL_expandableInput_clientInput',
+	headerText: 'gT-11229-KeyboardSymbolsDisplayLTRinRTL_expandableInput_header_text',
+	textToInput: 'How are you?'
+};

--- a/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL/GT-11229-KeyboardSymbolsDisplayLTRinRTL.js
+++ b/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL/GT-11229-KeyboardSymbolsDisplayLTRinRTL.js
@@ -1,0 +1,42 @@
+var
+	kind = require('enyo/kind');
+
+var
+	FittableRows = require('layout/FittableRows');
+
+var
+	BodyText = require('moonstone/BodyText'),
+	Divider = require('moonstone/Divider'),
+	ExpandableInput = require('moonstone/ExpandableInput'),
+	Scroller = require('moonstone/Scroller');
+
+var
+	load = require('../../../load'),
+	Test = kind({
+	name: 'test.GT-11229-KeyboardSymbolsDisplayLTRinRTL',
+	kind: FittableRows,
+	classes: 'moon enyo-unselectable enyo-fit',
+	components: [
+		{kind: Scroller, horizontal: 'hidden', fit: true, components: [
+			{classes:'moon-5h', components: [
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input', noneText: 'No Input'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input with Placeholder', noneText: 'No Input', placeholder: 'Placeholder'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input with Value', noneText: 'No Input', placeholder: 'Placeholder', value: 'Initial value'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Disabled Input', noneText: 'No Input', disabled: true, value: 'I am disabled.'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input with loooooooooooooooong text truncation', noneText: 'No Input with loooooooooooooooooong text truncation'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input with no value or noneText'},
+				{kind: ExpandableInput, oninput:'inputChanging', onChange:'inputChanged', content: 'Input with password type', type: 'password'}
+			]}
+		]},
+		{kind: Divider, content: 'Result'},
+		{kind: BodyText, name: 'console', content: 'Input:', allowHtml: true}
+	],
+	inputChanging: function(inSender, inEvent) {
+		this.$.console.setContent('<em>'+inSender.getContent() + '</em> changing: \'' + inEvent.originator.getValue() + '\'');
+	},
+	inputChanged: function(inSender) {
+		this.$.console.setContent('<em>'+inSender.getContent() + '</em> changed to: \'' + inSender.getValue() + '\'');
+	}
+});
+
+load(Test);

--- a/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL/package.json
+++ b/test/moonstone/ExpandableInput/GT-11229-KeyboardSymbolsDisplayLTRinRTL/package.json
@@ -1,0 +1,1 @@
+{"main": "GT-11229-KeyboardSymbolsDisplayLTRinRTL.js"}


### PR DESCRIPTION
I added `ilib = require('enyo-ilib')` to load.js because it's required to change the locale through the URL. I can change it to be added to the enyo test file, but I think that putting it in load.js makes more sense.

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com