### PR TITLE
Added function in grunt to remove moonstone extra tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_script:
     - serve -L .. &
 script:
     - echo -e "\x1b\x5b35;1m*** Starting tests...\x1b\x5b0m"
-    - grunt test:sauce:chrome
+    - MOONSTONE_EXTRA=false grunt test:sauce:chrome
     - echo -e "\x1b\x5b35;1m*** Tests complete\x1b\x5b0m"
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Several environment variables are supported for configuring how tests execute on
 * `WEBOS_IP` - IP Address of the webOS device. e.g. `WEBOS_IP=10.0.1.25`
 * `WEBOS_PORT` - Port of webOS device (default 22).  e.g. `WEBOS_PORT=9922`
 * `REMAP_LOCALHOST` - Looks for `localhost:3000` in web addresses and remaps them to the supplied IP address:port.  e.g.  `REMAP_LOCALHOST=10.0.1.9:8888`
+* `MOONSTONE_EXTRA` - Flag for moonstone extra library. `MOONSTONE_EXTRA=false` means run all tests that do not use moonstone extra. If you want to run moonstone extra tests just omit this variable.
 
 ## Contributing
 

--- a/moonstone-extra-checks.js
+++ b/moonstone-extra-checks.js
@@ -1,0 +1,38 @@
+var shelljs = require('shelljs');
+var _ = require('lodash');
+
+var getMoonstoneExtraTests = function(){
+	var result = shelljs.exec('egrep -rl --include="*.js" "moonstone-extra" test', {silent: true});
+	var resultsArray = result.output.split('\n');
+
+	var moonstoneTests = _.map(resultsArray, function(result){
+		if(result !== ''){
+			return result.split('/')[3];
+		}
+	});
+	moonstoneTests.pop();
+
+	return moonstoneTests;
+};
+
+var getAllUsedTests = function(){
+	if(process.env.MOONSTONE_EXTRA === 'false'){
+		var moonstoneTests = getMoonstoneExtraTests();
+
+		var moonstoneString = moonstoneTests.join('|');
+		var extraTests = moonstoneString.substring(0, moonstoneString.length - 1);
+
+		var nonExtraCmd = 'egrep -rlL --include="*specs.js" "'+extraTests+'" test';
+		var nonExtraTests = shelljs.exec(nonExtraCmd, {silent: true});
+		var nonExtraTestsArr = nonExtraTests.output.split('\n');
+		nonExtraTestsArr.pop();
+
+		//returns array of all tests without moonstone-extra
+		return nonExtraTestsArr;
+	} else {
+		return ['test/**/*-specs.js'];
+	}
+};
+
+exports.getAllUsedTests = getAllUsedTests;
+exports.getMoonstoneExtraTests = getMoonstoneExtraTests;


### PR DESCRIPTION
Used to fix enyo-pack errors that occur when a test environment can't run moonstone-extra e.g(saucelabs, TAS).

Enyo-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lgsvl.net